### PR TITLE
fix(zarf): Relax the default resource limits & request variables

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -21,19 +21,19 @@ variables:
     pattern: "^(true|false)$"
   - name: REQUESTS_CPU
     description: Number of CPU(s) to reserve for the pod
-    default: "1"
+    default: "0"
   - name: REQUESTS_MEMORY
     description: Amount of memory to reserve for the pod
-    default: "4Gi"
+    default: "0"
   - name: REQUESTS_GPU
     description: Must be greater or equal to 1 if GPU_ENABLED is true
     default: "0"
   - name: LIMITS_CPU
     description: Must be greater than or equal to REQUESTS_CPU
-    default: "1"
+    default: "0"
   - name: LIMITS_MEMORY
     description: Must be greater than or equal to REQUESTS_MEMORY
-    default: "20Gi"
+    default: "0"
   - name: LIMITS_GPU
     description: Must be greater than or equal to REQUESTS_GPU
     default: "0"


### PR DESCRIPTION
As a template, we should not be prescribing a default limit to the CPU and Memory allocations of deployments. This should be handled by the Zarf configurations that import this skeleton.

By having restrictive defaults, applications using this skeleton could unknowingly self-hinder themselves by not giving it enough resources to perform inference.